### PR TITLE
Fix code generation issue on changed fonts

### DIFF
--- a/Utils/Extension.cs
+++ b/Utils/Extension.cs
@@ -231,7 +231,7 @@ namespace OSHVisualGui
 
 		public static string ToCppString(this Font font)
 		{
-			return "FontManager::LoadFont(\"" + font.Name + "\", " + font.SizeInPoints.ToString(CultureInfo.InvariantCulture) + "f, false)";
+			return "FontManager::LoadFont(\"" + font.Name + "\", " + font.SizeInPoints.ToString("F2", CultureInfo.InvariantCulture) + "f, false)";
 		}
 
 		public static string ToCppString(this FileInfo file)


### PR DESCRIPTION
When a font has a SizeInPoints that has no decimal places (e.g. with Arial font in size 12), the generated code contains a ill-formed float literal (e.g. "9f" instead of "9.f" or "9.00f"). Fixing the decimal places to two digits seem to covering the precision of all font sizes nicely while always outputting a legal float literal.